### PR TITLE
added .classpath + .project to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ target
 *.iml
 *.log
 activemq-data
+/.classpath
+/.project

--- a/pom.xml
+++ b/pom.xml
@@ -346,6 +346,15 @@
           </filesets>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>      
     </plugins>
   </build>
 


### PR DESCRIPTION
I got the error: "Dynamic Web Module 3.0 requires Java 1.6 or newer. hawtio-camel-wiki line 1 Maven Java EE Configuration Problem"

Adding the maven compiler plugin to the pom resolved the problem
